### PR TITLE
Homework - Volumes, StorageClass, PV, PVC

### DIFF
--- a/kubernetes-volumes/cm.yaml
+++ b/kubernetes-volumes/cm.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm-homeworkdir
+  namespace: homework
+  labels:
+    app: nginx  
+data:
+  file: |
+    host: homework.otus
+    DEBUG: "false"    

--- a/kubernetes-volumes/configmap.yaml
+++ b/kubernetes-volumes/configmap.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm-practice2
+  namespace: homework
+  labels:
+    app: nginx  
+data:
+  default.conf: |
+    server {
+        listen       8000 default_server;
+        server_name  _;
+
+        default_type text/plain;
+
+        location / {
+            root   /homework;
+            index  index.html index.htm;
+        }
+
+        location /homepage {
+            return 200 "Rewrite is work!";
+        }
+
+        error_page  404         /404.html;
+    }
+  

--- a/kubernetes-volumes/deployment.yaml
+++ b/kubernetes-volumes/deployment.yaml
@@ -56,7 +56,7 @@ spec:
       volumes:
       - name: workdir
         persistentVolumeClaim:
-          claimName: hw-conf
+          claimName: pvc-default-cs
       - name: config
         configMap:
           name: cm-practice2

--- a/kubernetes-volumes/deployment.yaml
+++ b/kubernetes-volumes/deployment.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: practice2
+  namespace: homework
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      nodeSelector: 
+        homework: 'true'
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 8000
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: 8000
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        volumeMounts:
+        - name: workdir
+          mountPath: /homework
+        - name: config
+          mountPath: /etc/nginx/conf.d/
+        - name: homework-cm
+          mountPath: /homework/conf/
+        lifecycle:
+          preStop:
+              exec:
+                command: ['/bin/sh','-c','rm -f /homework/index.html']
+      initContainers:
+      - name: init
+        image: busybox:1.28
+        command: ['wget', 'https://otus.ru', '-O', '/init/index.html']
+        volumeMounts:
+        - name: workdir
+          mountPath: /init
+      volumes:
+      - name: workdir
+        persistentVolumeClaim:
+          claimName: hw-conf
+      - name: config
+        configMap:
+          name: cm-practice2
+      - name: homework-cm
+        configMap:
+          name: cm-homeworkdir

--- a/kubernetes-volumes/ingress.yaml
+++ b/kubernetes-volumes/ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-nginx
+  namespace: homework
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - host: homework.otus
+    http:
+      paths:
+      - path: "/"
+        pathType: Prefix      
+        backend:
+          service:
+            name: practice3
+            port:
+              number: 8000

--- a/kubernetes-volumes/namespace.yaml
+++ b/kubernetes-volumes/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework

--- a/kubernetes-volumes/pvc-default-sc.yaml
+++ b/kubernetes-volumes/pvc-default-sc.yaml
@@ -2,10 +2,9 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: pvc-custom-cs
+  name: pvc-default-cs
   namespace: homework  
 spec:
-  storageClassName: sc-custom
   accessModes:
   - ReadWriteOnce
   resources:

--- a/kubernetes-volumes/pvc.yaml
+++ b/kubernetes-volumes/pvc.yaml
@@ -1,0 +1,14 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: hw-conf
+  namespace: homework  
+spec:
+  storageClassName: sc-custom
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+

--- a/kubernetes-volumes/readme.md
+++ b/kubernetes-volumes/readme.md
@@ -19,8 +19,12 @@ sc-custom            k8s.io/minikube-hostpath   Retain          Immediate       
 standard (default)   k8s.io/minikube-hostpath   Delete          Immediate           false                  14d
 
 $ kubectl -n homework get pvc
-NAME      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
-hw-conf   Bound    pvc-716dcc4b-a759-417d-94b0-184ca7534cc8   1Gi        RWO            sc-custom      <unset>                 2m10s
+NAME             STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
+pvc-custom-cs    Bound    pvc-70be9405-3f71-4ccc-a126-f685af1c9e51   1Gi        RWO            sc-custom      <unset>                 83s
+pvc-default-cs   Bound    pvc-5acae0a2-0d2f-4352-a46d-41d29038ef04   1Gi        RWO            standard       <unset>                 90s
+
+$ k describe deploy practice2 |grep ClaimName
+ClaimName:  pvc-default-cs
 
 $ curl --resolve "homework.otus:80:$( minikube ip )" -i http://homework.otus/conf/file
 
@@ -35,3 +39,10 @@ Accept-Ranges: bytes
 
 host: homework.otus
 DEBUG: "false"
+
+Проверка задачи со *
+заменить в deployment.yaml claimName: pvc-default-cs на pvc-custom-cs
+$ kubernetes apply -f deployment.yaml
+
+$ k describe deploy practice2 |grep ClaimName
+ClaimName:  pvc-custom-cs

--- a/kubernetes-volumes/readme.md
+++ b/kubernetes-volumes/readme.md
@@ -1,0 +1,37 @@
+Порядок запуска:
+
+- рабочая директория /kubernetes-networks
+запустить все файлы
+
+$ kubectl -n homework get pod
+NAME                         READY   STATUS    RESTARTS   AGE
+practice2-84c75c4556-kd9kw   1/1     Running   0          12m
+practice2-84c75c4556-q9bzp   1/1     Running   0          12m
+practice2-84c75c4556-rjpx8   1/1     Running   0          12m
+
+$ kubectl get deploy -n homework
+NAME        READY   UP-TO-DATE   AVAILABLE   AGE
+practice2   3/3     3            3           81s
+
+$ kubectl -n homework get sc
+NAME                 PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
+sc-custom            k8s.io/minikube-hostpath   Retain          Immediate           true                   2m28s
+standard (default)   k8s.io/minikube-hostpath   Delete          Immediate           false                  14d
+
+$ kubectl -n homework get pvc
+NAME      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
+hw-conf   Bound    pvc-716dcc4b-a759-417d-94b0-184ca7534cc8   1Gi        RWO            sc-custom      <unset>                 2m10s
+
+$ curl --resolve "homework.otus:80:$( minikube ip )" -i http://homework.otus/conf/file
+
+HTTP/1.1 200 OK
+Date: Wed, 22 May 2024 06:59:13 GMT
+Content-Type: text/plain
+Content-Length: 39
+Connection: keep-alive
+Last-Modified: Wed, 22 May 2024 06:58:22 GMT
+ETag: "664d978e-27"
+Accept-Ranges: bytes
+
+host: homework.otus
+DEBUG: "false"

--- a/kubernetes-volumes/service.yaml
+++ b/kubernetes-volumes/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: practice3
+  namespace: homework
+spec:
+  ports:
+  - port: 80
+    targetPort: 8000
+  selector:
+    app: nginx
+  type: ClusterIP

--- a/kubernetes-volumes/storageClass.yaml
+++ b/kubernetes-volumes/storageClass.yaml
@@ -1,0 +1,15 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: sc-custom
+  namespace: homework  
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+provisioner: k8s.io/minikube-hostpath
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+mountOptions:
+  - discard
+volumeBindingMode: Immediate
+parameters:
+  guaranteedReadWriteLatency: "true"


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
- Создан манифест pvc-default-sc.yaml storageClass по-умолчанию
- Создан манифест cm.yaml для configMap, описывающий пары ключ-значение
- В манифесте deployment.yaml изменена спецификация emptyDir на PVC
- В манифесте deployment.yaml примонтирован ранее созданный configMap
- Создан манифест storageClass.yaml с provisioner
https://k8s.io/minikube-hostpath и reclaimPolicy Retain
- добавлен манифест pvc.yaml для кастомного storageClassа

## Как запустить проект:
- рабочая директория /kubernetes-volumes
- запустить все файлы
- добавить лейбл kubectl label nodes minikube homework=true
- для миникуба добавить ингрес minikube addons enable ingress
- проверить работоспособность
- заменить в deployment.yaml claimName: pvc-default-cs на pvc-custom-cs
- запустить kubernetes apply -f deployment.yaml
проверить работоспособность

## Как проверить работоспособность:
 - $ curl --resolve "homework.otus:80:$( minikube ip )" -i http://homework.otus/conf/file

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
